### PR TITLE
rwsdk v0.3.1 failing to start dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,17 +15,17 @@
     "tail": "wrangler tail"
   },
   "dependencies": {
-    "rwsdk": "0.2.0-alpha.14"
+    "rwsdk": "0.3.1"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.11.5",
-    "@cloudflare/workers-types": "^4.20250813.0",
-    "@types/node": "^24.2.1",
-    "@types/react": "^19.1.10",
-    "@types/react-dom": "^19.1.7",
+    "@cloudflare/vite-plugin": "1.12.3",
+    "@cloudflare/workers-types": "^4.20250904.0",
+    "@types/node": "^24.3.1",
+    "@types/react": "^19.1.12",
+    "@types/react-dom": "^19.1.9",
     "typescript": "^5.9.2",
-    "vite": "^7.1.2",
-    "wrangler": "^4.30.0"
+    "vite": "^7.1.4",
+    "wrangler": "^4.34.0"
   },
   "pnpm": {
     "peerDependencyRules": {


### PR DESCRIPTION
```txt
$pnpm dev
> safari-issue-29@1.0.0 dev /Users/jldec/cloudflare/redwood/safari-issue-29
> vite dev --force

4:38:04 PM [vite] (worker) Forced re-optimization of dependencies

🔍 Scanning for 'use client' and 'use server' directives...
4:38:06 PM [vite] (client) Forced re-optimization of dependencies (x2)
4:38:06 PM [vite] (ssr) Forced re-optimization of dependencies (x3)

  VITE v7.1.4  ready in 4122 ms

  ➜  Local:   http://localhost:5173/
  ➜  Network: use --host to expose
  ➜  Debug:   http://localhost:5173/__debug
  ➜  press h + enter to show help
✅ Scan complete.
✘ [ERROR] RWSDK directive scan failed:
Error: Build failed with 1 error:
error: The entry point "/Users/jldec/cloudflare/redwood/safari-issue-29/src/worker.tsx" cannot be marked as external
    at failureErrorWithLog (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1467:15)
    at /Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:926:25
    at runOnEndCallbacks (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1307:45)
    at buildResponseToResult (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:924:7)
    at /Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:951:16
    at responseCallbacks.<computed> (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:603:9)
    at handleIncomingPacket (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:658:12)
    at Socket.readFromStdout (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:581:7)
    at Socket.emit (node:events:518:28)
    at Socket.emit (node:domain:489:12) [plugin rwsdk:block-optimizer-for-scan]

  This error came from the "onStart" callback registered here:

    node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1141:20:
      1141 │       let promise = setup({
           ╵                     ^

    at setup (file:///Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/rwsdk@0.3.1_rollup@4.50.0_typescript@5.9.2_vite@7.1.4_@types+node@24.3.1_terser@5.44.0__c05fd1940fd4c017e8edeb4a5c1ee5b3/node_modules/rwsdk/dist/vite/directiveModulesDevPlugin.mjs:76:31)
    at handlePlugins (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1141:21)
    at buildOrContextImpl (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:854:5)
    at Object.buildOrContext (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:680:5)
    at /Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:2035:68
    at new Promise (<anonymous>)
    at Object.context (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:2035:27)
    at Object.context (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1877:58)
    at prepareEsbuildOptimizerRun (file:///Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/vite@7.1.4_@types+node@24.3.1_terser@5.44.0/node_modules/vite/dist/node/chunks/dep-C6pp_iVS.js:11329:32)

(!) Failed to run dependency scan. Skipping dependency pre-bundling. Error:   Failed to scan for dependencies from entries:
  /Users/jldec/cloudflare/redwood/safari-issue-29/src/worker.tsx

  ✘ [ERROR] RWSDK directive scan failed:
Error: Build failed with 1 error:
error: The entry point "/Users/jldec/cloudflare/redwood/safari-issue-29/src/worker.tsx" cannot be marked as external
    at failureErrorWithLog (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1467:15)
    at /Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:926:25
    at runOnEndCallbacks (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1307:45)
    at buildResponseToResult (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:924:7)
    at /Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:951:16
    at responseCallbacks.<computed> (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:603:9)
    at handleIncomingPacket (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:658:12)
    at Socket.readFromStdout (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:581:7)
    at Socket.emit (node:events:518:28)
    at Socket.emit (node:domain:489:12) [plugin rwsdk:block-optimizer-for-scan]

  This error came from the "onStart" callback registered here:

    node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1141:20:
      1141 │       let promise = setup({
           ╵                     ^

    at setup (file:///Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/rwsdk@0.3.1_rollup@4.50.0_typescript@5.9.2_vite@7.1.4_@types+node@24.3.1_terser@5.44.0__c05fd1940fd4c017e8edeb4a5c1ee5b3/node_modules/rwsdk/dist/vite/directiveModulesDevPlugin.mjs:76:31)
    at handlePlugins (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1141:21)
    at buildOrContextImpl (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:854:5)
    at Object.buildOrContext (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:680:5)
    at /Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:2035:68
    at new Promise (<anonymous>)
    at Object.context (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:2035:27)
    at Object.context (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1877:58)
    at prepareEsbuildScanner (file:///Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/vite@7.1.4_@types+node@24.3.1_terser@5.44.0/node_modules/vite/dist/node/chunks/dep-C6pp_iVS.js:10676:23)


    at failureErrorWithLog (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1467:15)
    at /Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:926:25
    at runOnEndCallbacks (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1307:45)
    at buildResponseToResult (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:924:7)
    at /Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:936:9
    at new Promise (<anonymous>)
    at requestCallbacks.on-end (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:935:54)
    at handleRequest (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:628:17)
    at handleIncomingPacket (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:653:7)
    at Socket.readFromStdout (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:581:7)
✘ [ERROR] RWSDK directive scan failed:
Error: Build failed with 1 error:
error: The entry point "/Users/jldec/cloudflare/redwood/safari-issue-29/src/worker.tsx" cannot be marked as external
    at failureErrorWithLog (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1467:15)
    at /Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:926:25
    at runOnEndCallbacks (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1307:45)
    at buildResponseToResult (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:924:7)
    at /Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:951:16
    at responseCallbacks.<computed> (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:603:9)
    at handleIncomingPacket (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:658:12)
    at Socket.readFromStdout (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:581:7)
    at Socket.emit (node:events:518:28)
    at Socket.emit (node:domain:489:12) [plugin rwsdk:block-optimizer-for-scan]

  This error came from the "onStart" callback registered here:

    node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1141:20:
      1141 │       let promise = setup({
           ╵                     ^

    at setup (file:///Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/rwsdk@0.3.1_rollup@4.50.0_typescript@5.9.2_vite@7.1.4_@types+node@24.3.1_terser@5.44.0__c05fd1940fd4c017e8edeb4a5c1ee5b3/node_modules/rwsdk/dist/vite/directiveModulesDevPlugin.mjs:76:31)
    at handlePlugins (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1141:21)
    at buildOrContextImpl (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:854:5)
    at Object.buildOrContext (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:680:5)
    at /Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:2035:68
    at new Promise (<anonymous>)
    at Object.context (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:2035:27)
    at Object.context (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1877:58)
    at prepareEsbuildOptimizerRun (file:///Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/vite@7.1.4_@types+node@24.3.1_terser@5.44.0/node_modules/vite/dist/node/chunks/dep-C6pp_iVS.js:11329:32)

/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1467
  let error = new Error(text);
              ^

Error: Error during dependency optimization:

✘ [ERROR] RWSDK directive scan failed:
Error: Build failed with 1 error:
error: The entry point "/Users/jldec/cloudflare/redwood/safari-issue-29/src/worker.tsx" cannot be marked as external
    at failureErrorWithLog (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1467:15)
    at /Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:926:25
    at runOnEndCallbacks (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1307:45)
    at buildResponseToResult (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:924:7)
    at /Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:951:16
    at responseCallbacks.<computed> (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:603:9)
    at handleIncomingPacket (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:658:12)
    at Socket.readFromStdout (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:581:7)
    at Socket.emit (node:events:518:28)
    at Socket.emit (node:domain:489:12) [plugin rwsdk:block-optimizer-for-scan]

  This error came from the "onStart" callback registered here:

    node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1141:20:
      1141 │       let promise = setup({
           ╵                     ^

    at setup (file:///Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/rwsdk@0.3.1_rollup@4.50.0_typescript@5.9.2_vite@7.1.4_@types+node@24.3.1_terser@5.44.0__c05fd1940fd4c017e8edeb4a5c1ee5b3/node_modules/rwsdk/dist/vite/directiveModulesDevPlugin.mjs:76:31)
    at handlePlugins (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1141:21)
    at buildOrContextImpl (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:854:5)
    at Object.buildOrContext (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:680:5)
    at /Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:2035:68
    at new Promise (<anonymous>)
    at Object.context (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:2035:27)
    at Object.context (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1877:58)
    at prepareEsbuildOptimizerRun (file:///Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/vite@7.1.4_@types+node@24.3.1_terser@5.44.0/node_modules/vite/dist/node/chunks/dep-C6pp_iVS.js:11329:32)


    at failureErrorWithLog (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1467:15)
    at /Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:926:25
    at /Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1345:9
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5) {
  errors: [Getter/Setter],
  warnings: [Getter/Setter]
}

Node.js v22.14.0
 ELIFECYCLE  Command failed with exit code 1.
 ```