### PR TITLE
update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,17 +15,17 @@
     "tail": "wrangler tail"
   },
   "dependencies": {
-    "rwsdk": "0.3.2"
+    "rwsdk": "0.3.10"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.12.3",
-    "@cloudflare/workers-types": "^4.20250905.0",
-    "@types/node": "^24.3.1",
-    "@types/react": "^19.1.12",
+    "@cloudflare/vite-plugin": "1.13.1",
+    "@cloudflare/workers-types": "^4.20250913.0",
+    "@types/node": "^24.4.0",
+    "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "typescript": "^5.9.2",
-    "vite": "^7.1.4",
-    "wrangler": "^4.34.0"
+    "vite": "^7.1.5",
+    "wrangler": "^4.37.0"
   },
   "pnpm": {
     "peerDependencyRules": {


### PR DESCRIPTION
Starting `vite dev` with the latest deps fails

```
$ pd

> safari-issue-29@1.0.0 dev /Users/jldec/cloudflare/redwood/safari-issue-29
> vite dev --force

4:00:06 PM [vite] (worker) Forced re-optimization of dependencies

🔍 Scanning for 'use client' and 'use server' directives...
✅ Scan complete.
file:///Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/rwsdk@0.3.10_rollup@4.50.2_typescript@5.9.2_vite@7.1.5_@types+node@24.4.0_terser@5.44.0_b76ad29c8ee0ad6f4944898a301f3068/node_modules/rwsdk/dist/vite/runDirectivesScan.mjs:213
        throw new Error(`RWSDK directive scan failed:\n${e.stack}`);
              ^

Error: RWSDK directive scan failed:
Error: Build failed with 1 error:
error: Must use "outdir" when there are multiple input files
    at failureErrorWithLog (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1467:15)
    at /Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:926:25
    at runOnEndCallbacks (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:1307:45)
    at buildResponseToResult (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:924:7)
    at /Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:951:16
    at responseCallbacks.<computed> (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:603:9)
    at handleIncomingPacket (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:658:12)
    at Socket.readFromStdout (/Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/esbuild@0.25.9/node_modules/esbuild/lib/main.js:581:7)
    at Socket.emit (node:events:518:28)
    at Socket.emit (node:domain:489:12)
    at runDirectivesScan (file:///Users/jldec/cloudflare/redwood/safari-issue-29/node_modules/.pnpm/rwsdk@0.3.10_rollup@4.50.2_typescript@5.9.2_vite@7.1.5_@types+node@24.4.0_terser@5.44.0_b76ad29c8ee0ad6f4944898a301f3068/node_modules/rwsdk/dist/vite/runDirectivesScan.mjs:213:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)

Node.js v22.14.0
 ELIFECYCLE  Command failed with exit code 1.
```